### PR TITLE
feat: add inter font from google fonts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.2",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.3",
+    "typeface-inter": "^3.15.1",
     "typescript": "^4.1.5",
     "web-vitals": "^1.1.0"
   },

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,14 +1,17 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './styles/index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import "typeface-inter";
+
+import React from "react";
+import ReactDOM from "react-dom";
+
+import "./styles/index.css";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
 
 ReactDOM.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById("root")
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,6 +164,7 @@
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.2",
         "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.3",
+        "typeface-inter": "^3.15.1",
         "typescript": "^4.1.5",
         "web-vitals": "^1.1.0"
       }
@@ -19707,6 +19708,11 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typeface-inter": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/typeface-inter/-/typeface-inter-3.15.1.tgz",
+      "integrity": "sha512-xlEvjfaTvFnr3ZmwM6fs5/KOKLpAuNksAUxiYfa6dKqZham2oTGm0gI1j/tcgxh1reihhrKbTFfFjtCV9wwxXA=="
+    },
     "node_modules/typescript": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
@@ -23215,6 +23221,7 @@
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.2",
         "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.3",
+        "typeface-inter": "^3.15.1",
         "typescript": "^4.1.5",
         "web-vitals": "^1.1.0"
       }
@@ -37434,6 +37441,11 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typeface-inter": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/typeface-inter/-/typeface-inter-3.15.1.tgz",
+      "integrity": "sha512-xlEvjfaTvFnr3ZmwM6fs5/KOKLpAuNksAUxiYfa6dKqZham2oTGm0gI1j/tcgxh1reihhrKbTFfFjtCV9wwxXA=="
     },
     "typescript": {
       "version": "4.1.5",


### PR DESCRIPTION
## Description

<!-- Write a short description of the changes in this PR and/or link to a related issue -->

- Adds Inter typeface to frontend app

## Checklist

- [ ] I have written unit tests for the code I added

## QA Steps

<!-- Provide some steps that another dev can follow to verify that your changes are working and bug-free -->

1. `npm i`
1. `cd frontend`
1. `npm start`
1. Verify Inter font loaded
