### PR TITLE
ci: add deployment to Heroku on pushes to dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,14 +35,26 @@ jobs:
       - name: Install Node Dependencies
         run: npm install
         
-      - name: Build
-        run: npm run-script build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-artifacts
+          path: |
+            ./backend/build/
+            ./frontend/build/
+            ./shared/build/
+          retention-days: 2
 
   deploy-frontend:
     runs-on: ubuntu-latest
     needs: [ build ]
     steps:
       - uses: actions/checkout@v2
+      
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-artifacts
 
       - uses: akhileshns/heroku-deploy@v3.11.10
         with:
@@ -57,6 +69,11 @@ jobs:
     needs: [ build ]
     steps:
       - uses: actions/checkout@v2
+      
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-artifacts
 
       - uses: akhileshns/heroku-deploy@v3.11.10
         with:


### PR DESCRIPTION
## Description

<!-- Write a short description of the changes in this PR and/or link to a related issue -->

- Closes #26 
- Create a new Github Action workflow that runs only on pushes to dev (the current integration branch)
- There are 3 jobs:
   - Build (builds the app and uploads build artifacts for later jobs to use)
   - Deploy frontend (deploys frontend docker container to dateam-frontend project on Heroku)
   - Deploy backend (deploys backend docker container to dateam-backend project on Heroku)

## Checklist

- [ ] I have written unit tests for the code I added

## QA Steps

<!-- Provide some steps that another dev can follow to verify that your changes are working and bug-free -->

1. Go to https://dateam-frontend.herokuapp.com/ and verify frontend is deployed
1. Go to https://dateam-backend.herokuapp.com/openapi and verify backend is deployed
