### PR TITLE
fix: add build command after install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install Node Dependencies
         run: npm install
         
+      - name: Build
+        run: npm run build
+        
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
## Description

<!-- Write a short description of the changes in this PR and/or link to a related issue -->

- Originally build was run postinstall, but that had issues with Docker. This change explicitly adds it
