### PR TITLE
fix: move comment in .env to a new line

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,9 +5,11 @@
 PORT=3001
 OUT_PORT=3001
 
-NODE_ENV=development # development, production
+# development, production
+NODE_ENV=development
 
-LOG_LEVEL=info       # error, info, debug
+# error, info, debug
+LOG_LEVEL=info
 
 DB_HOST=postgres
 DB_PORT=5432


### PR DESCRIPTION
## Description

<!-- Write a short description of the changes in this PR and/or link to a related issue -->

- Closes #95

## Checklist

- [ ] I have written unit tests for the code I added

## QA Steps

<!-- Provide some steps that another dev can follow to verify that your changes are working and bug-free -->

1. Update the local .env with the new template
2. Added the following line in App.ts 
```typescript
console.log(process.env.NODE_ENV)
console.log(process.env.LOG_LEVEL)
```
3. confirmed the correct value is printed
