### PR TITLE
refactor: pluralize endpoint names

### DIFF
--- a/backend/__tests__/API.spec.ts
+++ b/backend/__tests__/API.spec.ts
@@ -51,14 +51,14 @@ describe.only("GET /mock", () => {
  * Add a new test block for each API end point
  */
 
-describe("GET /api/patient/search: Search for a patient by ID or legal name", () => {
+describe("GET /api/patients/search: Search for a patient by ID or legal name", () => {
     var mockPatient = Mock.getMockPatient();
     var patientId = mockPatient.id;
     var patientName = mockPatient.name;
 
     test("Search by ID that exists", done => {
         request
-            .get(`/api/patient/search?query=${patientId}`)
+            .get(`/api/patients/search?query=${patientId}`)
             .expect('Content-Type', /json/)
             .expect(HttpCode.OK)
             .then(response => {
@@ -72,7 +72,7 @@ describe("GET /api/patient/search: Search for a patient by ID or legal name", ()
     });
     test("Search by name that exists", done => {
         request
-            .get(`/api/patient/search?query=${patientName}`)
+            .get(`/api/patients/search?query=${patientName}`)
             .expect('Content-Type', /json/)
             .expect(HttpCode.OK)
             .then(response => {
@@ -86,7 +86,7 @@ describe("GET /api/patient/search: Search for a patient by ID or legal name", ()
     });
     test("Search by name that does not exist", done => {
         request
-            .get("/api/patient/search?query=FakeName")
+            .get("/api/patients/search?query=FakeName")
             .expect('Content-Type', /json/)
             .expect(HttpCode.OK)
             .then(response => {
@@ -98,7 +98,7 @@ describe("GET /api/patient/search: Search for a patient by ID or legal name", ()
     });
     test("Search by ID that does not exist", done => {
         request
-            .get("/api/patient/search?query=FakeID")
+            .get("/api/patients/search?query=FakeID")
             .expect('Content-Type', /json/)
             .expect(HttpCode.OK)
             .then(response => {
@@ -110,10 +110,10 @@ describe("GET /api/patient/search: Search for a patient by ID or legal name", ()
     });
 });
 
-describe("GET /api/patient/{patientId}: Get a specific patient", () => {
+describe("GET /api/patients/{patientId}: Get a specific patient", () => {
     test("Return the specified patient", done => {
         request
-            .get("/api/patient/{patientId}")
+            .get("/api/patients/{patientId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -122,7 +122,7 @@ describe("GET /api/patient/{patientId}: Get a specific patient", () => {
     });
     test("Bad Request", done => {
         request
-            .get("/api/patient/{patientId}")
+            .get("/api/patients/{patientId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -131,7 +131,7 @@ describe("GET /api/patient/{patientId}: Get a specific patient", () => {
     });
     test("Not Found", done => {
         request
-            .get("/api/patient/{patientId}")
+            .get("/api/patients/{patientId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -140,10 +140,10 @@ describe("GET /api/patient/{patientId}: Get a specific patient", () => {
     });
 });
 
-describe("GET /api/procedure/{procedureId}: Get a specific procedure", () => {
+describe("GET /api/procedures/{procedureId}: Get a specific procedure", () => {
     test("Returns the requested procedure", done => {
         request
-            .get("/api/procedure/{procedureId}")
+            .get("/api/procedures/{procedureId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -152,7 +152,7 @@ describe("GET /api/procedure/{procedureId}: Get a specific procedure", () => {
     });
     test("Bad Request", done => {
         request
-            .get("/api/procedure/{procedureId}")
+            .get("/api/procedures/{procedureId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -161,7 +161,7 @@ describe("GET /api/procedure/{procedureId}: Get a specific procedure", () => {
     });
     test("Not Found", done => {
         request
-            .get("/api/procedure/{procedureId}")
+            .get("/api/procedures/{procedureId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -170,10 +170,10 @@ describe("GET /api/procedure/{procedureId}: Get a specific procedure", () => {
     });
 });
 
-describe("POST /api/form: Create a new form from an XML document", () => {
+describe("POST /api/forms: Create a new form from an XML document", () => {
     test("Successfully created form", done => {
         request
-            .post("/api/form")
+            .post("/api/forms")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -182,7 +182,7 @@ describe("POST /api/form: Create a new form from an XML document", () => {
     });
     test("Bad Request", done => {
         request
-            .post("/api/form")
+            .post("/api/forms")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -191,13 +191,13 @@ describe("POST /api/form: Create a new form from an XML document", () => {
     });
 });
 
-describe.only("GET /api/form/{formId}: Get a specific form", () => {
+describe.only("GET /api/forms/{formId}: Get a specific form", () => {
     var mockForm = Mock.getMockForm();
     var formId = mockForm.uid;
 
     test.only("Return Form matching query", done => {
         request
-            .get(`/api/form/${formId}`)
+            .get(`/api/forms/${formId}`)
             .expect('Content-Type', /json/)
             .expect(HttpCode.OK)
             .then(response => {
@@ -209,7 +209,7 @@ describe.only("GET /api/form/{formId}: Get a specific form", () => {
     });
     test("Bad Request", done => {
         request
-            .get("/api/form/{formId}")
+            .get("/api/forms/{formId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -218,7 +218,7 @@ describe.only("GET /api/form/{formId}: Get a specific form", () => {
     });
     test("Not Found", done => {
         request
-            .get("/api/form/{formId}")
+            .get("/api/forms/{formId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -227,10 +227,10 @@ describe.only("GET /api/form/{formId}: Get a specific form", () => {
     });
 });
 
-describe("POST /api/response: Create a new response", () => {
+describe("POST /api/responses: Create a new response", () => {
     test("Response created successfully", done => {
         request
-            .post("/api/response")
+            .post("/api/responses")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -239,7 +239,7 @@ describe("POST /api/response: Create a new response", () => {
     });
     test("Bad Request", done => {
         request
-            .post("/api/response")
+            .post("/api/responses")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -248,7 +248,7 @@ describe("POST /api/response: Create a new response", () => {
     });
     test("Not Found", done => {
         request
-            .post("/api/response")
+            .post("/api/responses")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -257,10 +257,10 @@ describe("POST /api/response: Create a new response", () => {
     });
 });
 
-describe("GET /api/response/{responseId}: Get a specific form response", () => {
+describe("GET /api/responses/{responseId}: Get a specific form response", () => {
     test("Returns the requested response", done => {
         request
-            .get("/api/response/{responseId}")
+            .get("/api/responses/{responseId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -269,7 +269,7 @@ describe("GET /api/response/{responseId}: Get a specific form response", () => {
     });
     test("Bad Request", done => {
         request
-            .get("/api/response/{responseId}")
+            .get("/api/responses/{responseId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -278,7 +278,7 @@ describe("GET /api/response/{responseId}: Get a specific form response", () => {
     });
     test("Not Found", done => {
         request
-            .get("/api/response/{responseId}")
+            .get("/api/responses/{responseId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -287,10 +287,10 @@ describe("GET /api/response/{responseId}: Get a specific form response", () => {
     });
 });
 
-describe("PUT /api/response/{responseId}: Update a response", () => {
+describe("PUT /api/responses/{responseId}: Update a response", () => {
     test("Response created successfully", done => {
         request
-            .put("/api/response/{responseId}")
+            .put("/api/responses/{responseId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -299,7 +299,7 @@ describe("PUT /api/response/{responseId}: Update a response", () => {
     });
     test("Bad Request", done => {
         request
-            .put("/api/response/{responseId}")
+            .put("/api/responses/{responseId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);
@@ -308,7 +308,7 @@ describe("PUT /api/response/{responseId}: Update a response", () => {
     });
     test("Not Found", done => {
         request
-            .put("/api/response/{responseId}")
+            .put("/api/responses/{responseId}")
             .expect(HttpCode.NOT_IMPLEMENTED)
             .end(function(err, res) {
                 if (err) return done(err);

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -23,7 +23,7 @@ externalDocs:
   description: "Find out more about our project"
   url: "https://umar-ahmed.gitbook.io/project-dateam/"
 paths:
-  /patient/search:
+  /patients/search:
     get:
       description: "Search for a patient by ID or legal name"
       tags:
@@ -44,7 +44,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/Patient"
 
-  /patient/{patientId}:
+  /patients/{patientId}:
     get:
       description: "Get a specific patient"
       tags:
@@ -68,7 +68,7 @@ paths:
         404:
           $ref: "#/components/responses/NotFound"
 
-  /procedure/{procedureId}:
+  /procedures/{procedureId}:
     get:
       description: Get a specific procedure
       tags:
@@ -91,7 +91,7 @@ paths:
         404:
           $ref: "#/components/responses/NotFound"
 
-  /form/parse:
+  /forms/parse:
     post:
       tags:
         - parser
@@ -115,7 +115,7 @@ paths:
         400:
           $ref: "#/components/responses/BadRequest"
 
-  /form:
+  /forms:
     post:
       tags:
         - form
@@ -127,7 +127,7 @@ paths:
         400:
           $ref: "#/components/responses/BadRequest"
 
-  /form/{formId}:
+  /forms/{formId}:
     get:
       description: Get a specific form
       tags:
@@ -151,7 +151,7 @@ paths:
         404:
           $ref: "#/components/responses/NotFound"
 
-  /response:
+  /responses:
     post:
       description: Create a new response
       tags:
@@ -164,7 +164,7 @@ paths:
         404:
           $ref: "#/components/responses/NotFound"
 
-  /response/{responseId}:
+  /responses/{responseId}:
     get:
       description: Get a specific form response
       tags:

--- a/backend/src/services/Form/FormAPI.ts
+++ b/backend/src/services/Form/FormAPI.ts
@@ -15,17 +15,17 @@ export class FormAPI {
     return this.router;
   }
 
-  /* GET /form/{formId} */
+  /* GET /forms/{formId} */
   private getForm() {
-    this.router.get("/form/:formId", FormController.read);
+    this.router.get("/forms/:formId", FormController.read);
   }
 
-  /* POST /form/{formId} */
+  /* POST /forms/{formId} */
   private postForm() {
-    this.router.post("/form", FormController.create);
+    this.router.post("/forms", FormController.create);
   }
 
   private parseForm() {
-    this.router.post("/form/parse", FormController.parse);
+    this.router.post("/forms/parse", FormController.parse);
   }
 }

--- a/backend/src/services/Patient/PatientAPI.ts
+++ b/backend/src/services/Patient/PatientAPI.ts
@@ -14,13 +14,13 @@ export class PatientAPI {
     return this.router;
   }
 
-  /* GET /patient/{patientId} */
+  /* GET /patients/{patientId} */
   private getPatient() {
-    this.router.get("/patient/:patientId", PatientController.read);
-    this.router.get("/patient/search", PatientController.search);
+    this.router.get("/patients/:patientId", PatientController.read);
+    this.router.get("/patients/search", PatientController.search);
   }
 
-  /* POST /patient/{patientId} */
+  /* POST /patients/{patientId} */
   private postPatient() {
     //this.router.post("/patient", Patient.create);
   }

--- a/backend/src/services/Procedure/ProcedureAPI.ts
+++ b/backend/src/services/Procedure/ProcedureAPI.ts
@@ -15,10 +15,10 @@ export class ProcedureAPI {
   }
 
   private getProcedure() {
-    this.router.get("/procedure/:procedureId", ProcedureController.read);
+    this.router.get("/procedures/:procedureId", ProcedureController.read);
   }
 
   private postProcedure() {
-    this.router.post("/procedure", ProcedureController.create);
+    this.router.post("/procedures", ProcedureController.create);
   }
 }

--- a/backend/src/services/Response/ResponseAPI.ts
+++ b/backend/src/services/Response/ResponseAPI.ts
@@ -15,17 +15,18 @@ export class ResponseAPI {
     return this.router;
   }
 
-  /* GET /response/{responseId} */
+  /* GET /responses/{responseId} */
   private getResponse() {
-    this.router.get("/response/:responseId", ResponseController.read);
+    this.router.get("/responses/:responseId", ResponseController.read);
   }
 
-  /* POST /response/{responseId} */
+  /* POST /responses */
   private postResponse() {
-    this.router.post("/response", ResponseController.create);
+    this.router.post("/responses", ResponseController.create);
   }
 
+  /* PUT /responses/{responseId} */
   private putResponse() {
-    this.router.put("/response/:responseId", ResponseController.update);
+    this.router.put("/responses/:responseId", ResponseController.update);
   }
 }

--- a/frontend/src/services/FormService.ts
+++ b/frontend/src/services/FormService.ts
@@ -1,17 +1,17 @@
 import { Model } from "@dateam/shared";
 
 /**
- * Preform a GET request to the /api/v1/form/:formId route
+ * Preform a GET request to the /api/v1/forms/:formId route
  *
  * @param formId An ID for the SDC form that is to be recived.
  * @returns A SDC Form Object
  */
 async function read(formId: number): Promise<Model.SDCForm> {
   try {
-    const formResponse = await fetch(`/api/v1/form/${formId}`, {
+    const formResponse = await fetch(`/api/v1/forms/${formId}`, {
       method: "GET",
     });
-    
+
     if (formResponse.status != 200) {
       throw Error(
         `Could not get form by ID. Error: ${formResponse.statusText}`


### PR DESCRIPTION
## Description

<!-- Write a short description of the changes in this PR and/or link to a related issue -->

- It's more intuitive to pluralize endpoint names because some endpoints return more than one instance of the resource
- ex. `/response` implies a single resource is returned, when you actually get an array of responses

## Checklist

- [ ] I have written unit tests for the code I added

## QA Steps

<!-- Provide some steps that another dev can follow to verify that your changes are working and bug-free -->

1. `npm run build`
1. `npm run dev:backend`
1.  `npm run dev: frontend`
1. Verify all endpoints in openapi are pluralized
1. Verify frontend still works correctly
