### PR TITLE
feat: added utils for shared module

### DIFF
--- a/shared/src/Utils.ts
+++ b/shared/src/Utils.ts
@@ -56,3 +56,73 @@ export class AnswerValidationError extends ValidationError {
           this.debugMessage = debugMessage || ""
      }
 }
+
+/**
+ * A helper function to print the form in abbreviated formate
+ * @param node The form to print
+ * @param response A response to the form to be printed along size
+ */
+export function printNode(node: Model.SDCNode, response?: Model.SDCFormResponse, 
+     curIndent: string = "", indent: string = "    "){
+
+     const print = (o: any) => { console.log(curIndent + o) }
+     let header = `<${node.constructor.name}> ${node.id} [${node.title}]`
+     let answer = response?.answers.find(a => a.questionID === node.id)
+     let printBody = ()=>{}
+
+     if (node instanceof Model.SDCListField){
+          header += ` min: ${node.minSelections}, max: ${node.maxSelections}`
+          printBody = ()=>{
+               print("options: ")
+               node.options.forEach(o => printNode(o, response, curIndent + indent))
+               print("children: ")
+               curIndent += indent
+          }
+     } else if (node instanceof Model.SDCListFieldItem){
+          header += ` deSiblings: ${node.selectionDeselectsSiblings}, deChildren: ${node.selectionDisablesChildren}`
+          printBody = ()=>{
+               if (node.textResponse) {
+                    print("textResponse: ")
+                    printNode(node.textResponse, response, curIndent + indent)
+               }
+          }
+     } else if (node instanceof Model.SDCTextField){
+          header += ` type: ${node.type}, textAfter: ${node.textAfterResponse}`
+     }
+
+     print(header)
+     curIndent += indent
+     if (answer) print(`answer: ${answer.responses}`)
+     printBody()
+
+     node.children.forEach(o => printNode(o, response, curIndent))
+}
+
+/** A helper function to access a sub node by id */
+export function findNode(node: Model.SDCNode, id: string): any{
+
+     function findNodes(node: Model.SDCNode, id: string): Model.SDCNode[]{
+          if (node.id === id) return [node]
+
+          let children = node.children.concat([]) // copy
+          if (node instanceof Model.SDCListField){
+               children = children.concat(node.options)
+          } else if (node instanceof Model.SDCListFieldItem){
+               if (node.textResponse) children.push(node.textResponse)
+          }
+
+          return children.flatMap(o => findNodes(o, id))
+     }
+     const matches = findNodes(node, id)
+     if (matches.length === 0) throw new Error("id not found for " + id)
+     if (matches.length > 1) throw new Error("duplicates found for id " + id)
+     return matches[0]
+}
+
+/** A helper function to access an answer by question id */
+export function findAnswer(response: Model.SDCFormResponse, id: string): Model.SDCAnswer{
+     const matches = response.answers.filter(o => o.questionID === id)
+     if (matches.length === 0) throw new Error("id not found for " + id)
+     if (matches.length > 1) throw new Error("duplicates found for id " + id)
+     return matches[0]
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -6,4 +6,4 @@ export * from "./ClassValidator";
 export * as Mocks from "./MockData"
 export * from "./FormResponseValidator"
 export * from "./TextFieldTypeMeta"
-export { ValidationError, ParsingError } from "./Utils"
+export { ValidationError, ParsingError, findNode, findAnswer, printNode } from "./Utils"


### PR DESCRIPTION
## Description

<!-- Write a short description of the changes in this PR and/or link to a related issue -->

Added helper functions
- printNode
- findNode
- findAnswer

## Checklist

- [ ] I have written unit tests for the code I added

## QA Steps
Test script
```typescript
import { findNode, findAnswer, printNode } from "./Utils";

let form = Mocks.buildFormComplete()
let response = Mocks.buildFormResponseComplete()

findNode(form, "listText").type = "string"
findAnswer(response, "listText").responses = ["A valida string response"]

printNode(form, response)
```
Expected result
```
<SDCForm> covid-19-test-11b0e9 [Covid19Test]
    <SDCDisplayItem> display-0463f4 [Please fill out this form]
    <SDCSection> section-878829 [Main Section]
        <SDCTextField> text-1 [Weight] type: int, textAfter: kg
            answer: 5
        <SDCListField> list-1 [Multiple Choice list-6cf3ab] min: 1, max: 1
            answer: list-1-t,list-1-1,list-1-2
            options: 
                <SDCListFieldItem> list-1-0 [option listitem-2091ef] deSiblings: false, deChildren: false
                <SDCListFieldItem> list-1-1 [option listitem-507617] deSiblings: false, deChildren: false
                <SDCListFieldItem> list-1-2 [option listitem-4135ac] deSiblings: false, deChildren: false
                <SDCListFieldItem> list-1-3 [option listitem-ee6e73] deSiblings: false, deChildren: false
                <SDCListFieldItem> list-1-t [option listitem-f59908] deSiblings: false, deChildren: false
                    textResponse: 
                        <SDCTextField> listText [Weight] type: string, textAfter: kg
                            answer: A valida string response
            children: 
```