### PR TITLE
Fix failing backend test

### DIFF
--- a/backend/src/services/Form/FormController.ts
+++ b/backend/src/services/Form/FormController.ts
@@ -9,8 +9,10 @@ export const FormController = {
   },
 
   read: function (req: Request, res: Response) {
-    const sdcForm = Mocks.buildFormComplete();
-    const serialized = GenericJsonSerializer.encode(sdcForm, Model.SDCForm)
+    const targetUID: string = req.url.substring(req.url.lastIndexOf("/") + 1);
+    const sdcForm: Model.SDCForm = Mocks.buildFormComplete();
+    sdcForm.uid = targetUID;
+    const serialized = GenericJsonSerializer.encode(sdcForm, Model.SDCForm);
 
     res.status(HttpCode.OK).send(serialized);
   },
@@ -27,8 +29,8 @@ export const FormController = {
 
   parse: function (req: Request, res: Response) {
     const sdcForm = Mocks.buildFormComplete();
-    const serialized = GenericJsonSerializer.encode(sdcForm, Model.SDCForm)
+    const serialized = GenericJsonSerializer.encode(sdcForm, Model.SDCForm);
 
     res.status(HttpCode.OK).send(serialized);
-  }
+  },
 };


### PR DESCRIPTION
Cause:  An update in PR #140.

Summary:
In that PR, Mock form's uid is generated dynamically. Prior, it was a static value; now repeated calls to generate a Mock will create a new UID. Prior, the test builds a Mock form and requests that form's UID from the API, however, the API also generates a mock form so the UID's do not match.

Fix: In the API, update the mock form so that it returns the correct UID that was requested by the call.

Closes 160

## Checklist

- [x ] ~~I have written unit tests for the code I added~~ The previously failing unit test now passes

## QA Steps


1. Ensure Backend: CI passes ✔️ (optional: specifically ensure the test " GET /api/forms/{formId}: ✓ Return Form matching query" passes in the CI details )
