### PR TITLE
refactor: move existing responses pages to /responses/manage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,10 +41,11 @@ function App() {
                   <Route path="/home" component={Home} />
                   <Route exact path="/patients" component={Patients} />
                   <Route exact path="/procedures" component={Procedures} />
-                  <Route path="/responses" component={Responses} />
+                  <Route path="/responses/manage" component={Responses} />
                   <Route path="/forms" component={Forms} />
                   <Route exact path="/404" component={NotFound} />
-                  <Redirect exact path="/" to="/responses" />
+                  <Redirect exact path="/" to="/home" />
+                  <Redirect exact path="/responses" to="/responses/manage" />
                   <Redirect to="/404" />
                 </Switch>
               </AnimatePresence>

--- a/frontend/src/components/FormsPanel/FormsPanel.tsx
+++ b/frontend/src/components/FormsPanel/FormsPanel.tsx
@@ -56,7 +56,7 @@ export default function FormsPanel(props: IFormsPanelProps) {
       className="z-20 w-1/2 w-full px-6 py-12 space-y-8 overflow-y-auto rounded-lg shadow-xl lg:w-1/4 bg-gray-50"
     >
       <div className="space-y-2">
-        <h2 className="text-3xl font-medium tracking-tighter">Choose a Form</h2>
+        <h2 className="text-3xl font-medium tracking-tighter">Responses</h2>
         <p className="text-gray-600">
           Responses are grouped by the form they come from.
         </p>

--- a/frontend/src/components/NewPatientModel/NewPatientModel.tsx
+++ b/frontend/src/components/NewPatientModel/NewPatientModel.tsx
@@ -7,109 +7,109 @@ import { notify } from "../../components/Notification/Notification";
 import PatientService from "../../services/PatientService";
 
 function NewPatientModal(props: {
-    showModal: boolean;
-    goToRespones: boolean;
-    refetch?: any;
-    setShowModal?: (val: boolean) => void;
+  showModal: boolean;
+  goToRespones: boolean;
+  refetch?: any;
+  setShowModal?: (val: boolean) => void;
 }) {
-    const { showModal, setShowModal } = props;
-    const [patientName, setPatientName] = useState("");
-    const [patientId, setPatientId] = useState("");
-    const { formId } = useParams<{ formId: string }>();
-    const hist = useHistory();
+  const { showModal, setShowModal } = props;
+  const [patientName, setPatientName] = useState("");
+  const [patientId, setPatientId] = useState("");
+  const { formId } = useParams<{ formId: string }>();
+  const hist = useHistory();
 
-    const onCreateClick = () => {
-        const newPatient = new Model.Patient({
-            name: patientName,
-            id: patientId,
-        });
-        PatientService.create(newPatient)
-            .then((patientId) => {
-                console.log(patientId);
-                if (props.goToRespones) {
-                    hist.push(`/responses/${formId}?patient=${patientId}`);
-                }
-                if (props.refetch) {
-                    props.refetch();
-                }
-                if (setShowModal) {
-                    setShowModal(!showModal);
-                }
-            })
-            .catch((err) => {
-                notify.error(err.message);
-                console.log(err);
-            });
-    };
+  const onCreateClick = () => {
+    const newPatient = new Model.Patient({
+      name: patientName,
+      id: patientId,
+    });
+    PatientService.create(newPatient)
+      .then((patientId) => {
+        console.log(patientId);
+        if (props.goToRespones) {
+          hist.push(`/responses/manage/${formId}?patient=${patientId}`);
+        }
+        if (props.refetch) {
+          props.refetch();
+        }
+        if (setShowModal) {
+          setShowModal(!showModal);
+        }
+      })
+      .catch((err) => {
+        notify.error(err.message);
+        console.log(err);
+      });
+  };
 
-    return (
-        <div data-testid="newpatientmodel">
-            <Modal setShowModal={setShowModal}>
-                <div className="flex flex-col p-4">
-                    <div className="flex space-x-8">
-                        <PersonSVG />
-                        <span className="flex flex-col">
-                            {" "}
-                            <h2 className="text-2xl font-semibold text-left">
-                                Enter the patient information.
+  return (
+    <div data-testid="newpatientmodel">
+      <Modal setShowModal={setShowModal}>
+        <div className="flex flex-col p-4">
+          <div className="flex space-x-8">
+            <PersonSVG />
+            <span className="flex flex-col">
+              {" "}
+              <h2 className="text-2xl font-semibold text-left">
+                Enter the patient information.
               </h2>
-                            <h3 className="text-left text-gray-600">
-                                Fill in the following details and hit Create.
+              <h3 className="text-left text-gray-600">
+                Fill in the following details and hit Create.
               </h3>{" "}
-                        </span>
-                    </div>
-                    <div className="flex flex-col mt-8 space-y-8">
-                        <div className="w-1/2 space-y-2 text-left md:w-full">
-                            <label className="text-lg font-bold uppercase">Full Name</label>
-                            <FormInput
-                                state={patientName}
-                                setState={setPatientName}
-                                type="text"
-                                placeholder=""
-                            />
-                        </div>
-                        <div className="flex flex-col w-1/2 space-y-2 text-left md:w-full">
-                            <label className="text-lg font-bold uppercase">Patient ID</label>
-                            <FormInput
-                                state={patientId}
-                                setState={setPatientId}
-                                type="text"
-                                placeholder=""
-                            />
-                            <label className="text-sm text-gray-600">
-                                Typically this is the patient’s OHIP number.
-                            </label>
-                        </div>
-                        <button
-                            onClick={onCreateClick}
-                            className="w-1/2 p-3 text-white bg-gray-800 rounded-lg md:w-full hover:bg-gray-600"
-                        >
-                            {" "}
+            </span>
+          </div>
+          <div className="flex flex-col mt-8 space-y-8">
+            <div className="w-1/2 space-y-2 text-left md:w-full">
+              <label className="text-lg font-bold uppercase">Full Name</label>
+              <FormInput
+                state={patientName}
+                setState={setPatientName}
+                type="text"
+                placeholder=""
+              />
+            </div>
+            <div className="flex flex-col w-1/2 space-y-2 text-left md:w-full">
+              <label className="text-lg font-bold uppercase">Patient ID</label>
+              <FormInput
+                state={patientId}
+                setState={setPatientId}
+                type="text"
+                placeholder=""
+              />
+              <label className="text-sm text-gray-600">
+                Typically this is the patient’s OHIP number.
+              </label>
+            </div>
+            <button
+              onClick={onCreateClick}
+              className="w-1/2 p-3 text-white bg-gray-800 rounded-lg md:w-full hover:bg-gray-600"
+            >
+              {" "}
               Create{" "}
-                        </button>
-                    </div>
-                </div>
-            </Modal>
+            </button>
+          </div>
         </div>
-    );
+      </Modal>
+    </div>
+  );
 }
 
 function PersonSVG() {
-    return (
-        <svg
-            width="68"
-            height="68"
-            viewBox="0 0 68 68"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-        >
-            <rect width="68" height="68" rx="34" fill="#7B61FF" fillOpacity="0.15" />
-            <path
-                d="M34 19C35.65 19 37 20.35 37 22C37 23.65 35.65 25 34 25C32.35 25 31 23.65 31 22C31 20.35 32.35 19 34 19ZM47.5 29.5H38.5V49H35.5V40H32.5V49H29.5V29.5H20.5V26.5H47.5V29.5Z"
-                fill="#7B61FF"
-            />
-        </svg>
-    );
+  return (
+    <svg
+      width="68"
+      height="68"
+      viewBox="0 0 68 68"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect width="68" height="68" rx="34" fill="#7B61FF" fillOpacity="0.15" />
+      <path
+        d="M34 19C35.65 19 37 20.35 37 22C37 23.65 35.65 25 34 25C32.35 25 31 23.65 31 22C31 20.35 32.35 19 34 19ZM47.5 29.5H38.5V49H35.5V40H32.5V49H29.5V29.5H20.5V26.5H47.5V29.5Z"
+        fill="#7B61FF"
+      />
+    </svg>
+  );
 }
 
 export default NewPatientModal;

--- a/frontend/src/pages/Responses/FormRendererPanel.tsx
+++ b/frontend/src/pages/Responses/FormRendererPanel.tsx
@@ -24,7 +24,7 @@ export default function FormRendererPanel() {
       exit={{ opacity: 0 }}
       className="relative w-full min-h-full overflow-y-auto rounded-lg shadow-2xl sm:w-1/2 lg:w-1/2 bg-gray-50"
     >
-      <Link to={`/responses/${formId}`}>
+      <Link to={`/responses/manage/${formId}`}>
         <CloseButton />
       </Link>
 

--- a/frontend/src/pages/Responses/Responses.test.tsx
+++ b/frontend/src/pages/Responses/Responses.test.tsx
@@ -10,7 +10,9 @@ import { Responses } from ".";
 
 function renderResponses(): { history: MemoryHistory } {
   const queryClient = new QueryClient();
-  const history = createMemoryHistory({ initialEntries: ["/responses"] });
+  const history = createMemoryHistory({
+    initialEntries: ["/responses/manage"],
+  });
   render(
     <QueryClientProvider client={queryClient}>
       <Router history={history}>
@@ -84,7 +86,7 @@ describe("Responses", () => {
     await waitFor(() => screen.getByText(/Ujash/));
     fireEvent.click(screen.getByText("Ujash"));
 
-    expect(history.location.pathname).toBe("/responses/form1/response1");
+    expect(history.location.pathname).toBe("/responses/manage/form1/response1");
   });
 
   it("navigates back when you close a panel", async () => {
@@ -95,17 +97,17 @@ describe("Responses", () => {
     await waitFor(() => screen.getByText(/Ujash/));
     fireEvent.click(screen.getByText("Ujash"));
 
-    expect(history.location.pathname).toBe("/responses/form1/response1");
+    expect(history.location.pathname).toBe("/responses/manage/form1/response1");
 
     const closeButtons: HTMLElement[] = screen.getAllByLabelText("close");
     expect(closeButtons).toHaveLength(2);
 
     fireEvent.click(closeButtons[1]);
 
-    expect(history.location.pathname).toBe("/responses/form1");
+    expect(history.location.pathname).toBe("/responses/manage/form1");
 
     fireEvent.click(closeButtons[0]);
 
-    expect(history.location.pathname).toBe("/responses");
+    expect(history.location.pathname).toBe("/responses/manage");
   });
 });

--- a/frontend/src/pages/Responses/Responses.tsx
+++ b/frontend/src/pages/Responses/Responses.tsx
@@ -20,20 +20,26 @@ export default function Responses() {
         <Route
           exact
           path={[
-            "/responses",
-            "/responses/:formId",
-            "/responses/:formId/:responseId",
+            "/responses/manage",
+            "/responses/manage/:formId",
+            "/responses/manage/:formId/:responseId",
           ]}
           component={FormsResponsePanel}
         />
         <Route
           exact
-          path={["/responses/:formId", "/responses/:formId/:responseId"]}
+          path={[
+            "/responses/manage/:formId",
+            "/responses/manage/:formId/:responseId",
+          ]}
           component={ResponsesPanel}
         />
         <Route
           exact
-          path={["/responses/:formId", "/responses/:formId/:responseId"]}
+          path={[
+            "/responses/manage/:formId",
+            "/responses/manage/:formId/:responseId",
+          ]}
           component={FormRendererPanel}
         />
       </div>
@@ -42,5 +48,5 @@ export default function Responses() {
 }
 
 function FormsResponsePanel() {
-  return <FormsPanel baseUri="/responses" />;
+  return <FormsPanel baseUri="/responses/manage" />;
 }

--- a/frontend/src/pages/Responses/ResponsesPanel.tsx
+++ b/frontend/src/pages/Responses/ResponsesPanel.tsx
@@ -9,123 +9,124 @@ import { Model } from "@dateam/shared";
 import { NewPatientModel } from "../../components/NewPatientModel";
 
 export default function ResponsesPanel() {
-    const { formId, responseId } = useParams<{
-        formId: string;
-        responseId: string;
-    }>();
-    const [formResponseSearch, setFormResponseSearch] = useState("");
-    const { data: formResponses } = useFormResponses(formId);
-    const [showNewModel, setNewShowModel] = useState(false);
+  const { formId, responseId } = useParams<{
+    formId: string;
+    responseId: string;
+  }>();
+  const [formResponseSearch, setFormResponseSearch] = useState("");
+  const { data: formResponses } = useFormResponses(formId);
+  const [showNewModel, setNewShowModel] = useState(false);
 
-    const onNewBtnClick = () => setNewShowModel(true);
+  const onNewBtnClick = () => setNewShowModel(true);
 
-    const responseFormInfoBlocks = formResponses?.map((formResponse, i) => {
-        return (
-            <Link
-                to={`/responses/${formResponse.formId}/${formResponse.uid}`}
-                key={formResponse.uid}
-            >
-                <ResponsesCard
-                    responseForm={formResponse}
-                    isSelected={responseId === formResponse.uid}
-                />
-            </Link>
-        );
-    });
-
+  const responseFormInfoBlocks = formResponses?.map((formResponse, i) => {
     return (
-        <>
-            {showNewModel && (
-                <NewPatientModel
-                    showModal={showNewModel}
-                    setShowModal={setNewShowModel}
-                    goToRespones={true}
-                />
-            )}
-            <motion.div
-                data-testid="responses-panel"
-                variants={{
-                    initial: {
-                        opacity: 0,
-                        x: -10,
-                    },
-                    animate: {
-                        opacity: 1,
-                        x: 0,
-                        transition: {
-                            ease: "easeInOut",
-                            when: "beforeChildren",
-                            staggerChildren: 0.1,
-                        },
-                    },
-                }}
-                initial="initial"
-                animate="animate"
-                className="relative z-10 w-1/2 w-full px-6 py-12 overflow-y-auto rounded-lg shadow-xl lg:w-1/4 bg-gray-50"
-            >
-                <Link to={`/responses`}>
-                    <CloseButton />
-                </Link>
-
-                <div className="space-y-8">
-                    <div className="space-y-2">
-                        <div className="flex justify-between">
-                            <h2 className="text-3xl font-medium tracking-tighter">
-                                Responses
-              </h2>
-                            <button
-                                onClick={onNewBtnClick}
-                                className="w-20 h-8 mt-2 font-semibold bg-gray-300 rounded-lg hover:bg-gray-800 hover:text-white text-bold"
-                            >
-                                New
-              </button>
-                        </div>
-
-                        <p className="text-gray-600">
-                            Responses are grouped by the form they come from.
-            </p>
-                    </div>
-                    <FormInput
-                        placeholder="Filter by name."
-                        type="text"
-                        state={formResponseSearch}
-                        setState={setFormResponseSearch}
-                    />
-                    <motion.div className="space-y-4">
-                        {responseFormInfoBlocks}
-                    </motion.div>
-                </div>
-            </motion.div>
-        </>
+      <Link
+        to={`/responses/manage/${formResponse.formId}/${formResponse.uid}`}
+        key={formResponse.uid}
+      >
+        <ResponsesCard
+          responseForm={formResponse}
+          isSelected={responseId === formResponse.uid}
+        />
+      </Link>
     );
+  });
+
+  return (
+    <>
+      {showNewModel && (
+        <NewPatientModel
+          showModal={showNewModel}
+          setShowModal={setNewShowModel}
+          goToRespones={true}
+        />
+      )}
+      <motion.div
+        data-testid="responses-panel"
+        variants={{
+          initial: {
+            opacity: 0,
+            x: -10,
+          },
+          animate: {
+            opacity: 1,
+            x: 0,
+            transition: {
+              ease: "easeInOut",
+              when: "beforeChildren",
+              staggerChildren: 0.1,
+            },
+          },
+        }}
+        initial="initial"
+        animate="animate"
+        className="relative z-10 w-1/2 w-full px-6 py-12 overflow-y-auto rounded-lg shadow-xl lg:w-1/4 bg-gray-50"
+      >
+        <Link to={`/responses/manage`}>
+          <CloseButton />
+        </Link>
+
+        <div className="space-y-8">
+          <div className="space-y-2">
+            <div className="flex justify-between">
+              <h2 className="text-3xl font-medium tracking-tighter">
+                Responses
+              </h2>
+              <button
+                onClick={onNewBtnClick}
+                className="w-20 h-8 mt-2 font-semibold bg-gray-300 rounded-lg hover:bg-gray-800 hover:text-white text-bold"
+              >
+                New
+              </button>
+            </div>
+
+            <p className="text-gray-600">
+              Responses are grouped by the form they come from.
+            </p>
+          </div>
+          <FormInput
+            placeholder="Filter by name."
+            type="text"
+            state={formResponseSearch}
+            setState={setFormResponseSearch}
+          />
+          <motion.div className="space-y-4">
+            {responseFormInfoBlocks}
+          </motion.div>
+        </div>
+      </motion.div>
+    </>
+  );
 }
 
 function ResponsesCard({
-    responseForm,
-    isSelected = false,
+  responseForm,
+  isSelected = false,
 }: {
-    responseForm: Model.SDCFormResponse;
-    isSelected: boolean;
+  responseForm: Model.SDCFormResponse;
+  isSelected: boolean;
 }) {
-    const { data: patient } = usePatient(responseForm.patientID);
-    return (
-        <motion.div
-            variants={{
-                initial: { opacity: 0, y: 10 },
-                animate: { opacity: 1, y: 0 },
-            }}
-            key={responseForm.uid}
-            className={`p-4 cursor-pointer ${isSelected
-                ? "bg-gray-900 text-white"
-                : "text-black bg-gray-50 hover:bg-gray-200"
-                } rounded-lg transition-colors`}
-        >
-            <span
-                className={`text-xs ${isSelected ? "text-gray-400" : "text-gray-500"}`}
-            >
-                ID: {responseForm.uid}
-            </span>
-            <h3 className="text-lg font-medium">{patient?.name}</h3>
-        </motion.div>
-    );
+  const { data: patient } = usePatient(responseForm.patientID);
+  return (
+    <motion.div
+      variants={{
+        initial: { opacity: 0, y: 10 },
+        animate: { opacity: 1, y: 0 },
+      }}
+      key={responseForm.uid}
+      className={`p-4 cursor-pointer ${
+        isSelected
+          ? "bg-gray-900 text-white"
+          : "text-black bg-gray-50 hover:bg-gray-200"
+      } rounded-lg transition-colors`}
+    >
+      <span
+        className={`text-xs ${isSelected ? "text-gray-400" : "text-gray-500"}`}
+      >
+        ID: {responseForm.uid}
+      </span>
+      <h3 className="text-lg font-medium">{patient?.name}</h3>
+    </motion.div>
+  );
 }


### PR DESCRIPTION
## Description

<!-- Write a short description of the changes in this PR and/or link to a related issue -->

- Closes #197

## Checklist

- [x] I have written unit tests for the code I added

## QA Steps

<!-- Provide some steps that another dev can follow to verify that your changes are working and bug-free -->

1. Start frontend
1. Go to http://localhost:3000
1. Verify that responses pages are all under `/responses/manage`
1. Verify that `/responses` redirects to `/responses/manage`
